### PR TITLE
Adds MkDocs to the list of dependencies needed to build for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can read these docs [online](http://www.cocos2d-x.org/docs).
 * export TEXROOT=/usr/local/texlive/2014basic/bin/universal-darwin/
 * export PATH=$TEXROOT:$PATH
 
+* MkDocs: http://www.mkdocs.org/
+
 * To build the c++ API Ref you need a customized Doxygen version from https://github.com/zilongshanren/doxygen
 
 * To build the JavaScript API Ref you need __jsdoc_toolkit__ which is usually placed in __<Cocos2d-x root>/web/tools__. It can be found here: http://cocos2d-x.org/docs/jsdoc_toolkit-2.4.0.zip

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ You can read these docs [online](http://www.cocos2d-x.org/docs).
 * To build the JavaScript API Ref you need __jsdoc_toolkit__ which is usually placed in __<Cocos2d-x root>/web/tools__. It can be found here: http://cocos2d-x.org/docs/jsdoc_toolkit-2.4.0.zip
 
 ## How to run/test these docs
-* __cd <where you cloned this repo>__
+* __cd \<*where you cloned this repo*\>__
 * run __build.sh --all__
 * run __mkdocs serve__
 
 Any changes made while __mkdocs serve__ is running are automatically rebuilt.
 
 ## How to build for deployment
-* __cd <where you cloned this repo>__
+* __cd \<*where you cloned this repo*\>__
 * run __build.sh --all__
 
 Content is built in __docs__ and deployed to __site__. This script also builds the
@@ -67,7 +67,7 @@ ePub and PDF versions as well as deploys out to our staging server and http://ww
 ## API-Ref
 The legacy API-Refs are now downloaded and deployed as needed. No need for us to store these
 in GitHub as they don't change.
-* __cd <where you cloned this repo>__
+* __cd \<*where you cloned this repo*\>__
 * run __build.sh --legacyapi__
 
 ## When contributing


### PR DESCRIPTION
The "What do you need to build for OS X?" list was missing MkDocs. This commit adds it.