### PR TITLE
Fixes text in README that was getting removed by Github Markdown parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ You can read these docs [online](http://www.cocos2d-x.org/docs).
 * To build the JavaScript API Ref you need __jsdoc_toolkit__ which is usually placed in __<Cocos2d-x root>/web/tools__. It can be found here: http://cocos2d-x.org/docs/jsdoc_toolkit-2.4.0.zip
 
 ## How to run/test these docs
-* __cd <where you cloned this repo>__
+* __cd \<*where you cloned this repo*\>__
 * run __build.sh --all__
 * run __mkdocs serve__
 
 Any changes made while __mkdocs serve__ is running are automatically rebuilt.
 
 ## How to build for deployment
-* __cd <where you cloned this repo>__
+* __cd \<*where you cloned this repo*\>__
 * run __build.sh --all__
 
 Content is built in __docs__ and deployed to __site__. This script also builds the
@@ -65,7 +65,7 @@ ePub and PDF versions as well as deploys out to our staging server and http://ww
 ## API-Ref
 The legacy API-Refs are now downloaded and deployed as needed. No need for us to store these
 in GitHub as they don't change.
-* __cd <where you cloned this repo>__
+* __cd \<*where you cloned this repo*\>__
 * run __build.sh --legacyapi__
 
 ## When contributing


### PR DESCRIPTION
Github was just completely removing the text "<where you cloned this repo>".